### PR TITLE
Power on/off works single time, after that refresh cannot be parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
+# This is a fork, to share a small fix for MagicHome LED Pixel controller (LD382A)
+
+My wifi controller returns after power on / off 4 bytes of data, like an acknowledgement. The logic of the adapter cannot parse these additional 4 bytes, so all calls after it were not parsed anymore and so the ioBroker objects are not updated. The fix includes a way to ignore these 4 bytes. Maybe there is a better way, to do it? I would also recommend to remove the buffer and parse data array directly in onData method. Don't know, why we need a buffer there.
+
+My issue was here (after debug log enabled):
+
+```
+write: 81 8a 8b 96 <-- Write "Refresh command"
+raw data length: 14
+raw data: 81 a1 24 00 61 64 ff ff ff 02 03 01 68 76 <-- Receive data, starts every time with 0x81, when there is a refresh before (contains colors r,g,b,w, power on/off, progOn, ...)
+onData: raw: 81 a1 24 00 61 64 ff ff ff 02 03 01 68 76
+onData: {"on":false,"progNo":0,"progOn":false,"preogSpeed":100,"red":255,"green":255,"blue":255,"white":2} <-- Refresh works, can be parsed - okay
+write: 71 23 0f a3 <-- Send Power On or off command
+raw data length: 4 <-- The controller returns 4 bytes like an acknowledgement. These are ignored by the fix.
+raw data: 0f 71 23 a3
+raw data length: 14 <-- this is a normal refresh response
+raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
+onData: raw: 0f 71 23 a3 81 a1 23 00 61 64 ff ff ff 02 <-- The buffer now has 4 bytes ack + 14 bytes response = not parsable anymore
+raw data length: 14
+raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
+onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
+raw data length: 14
+raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
+onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
+write: 81 8a 8b 96 <-- manual refresh also don't work, because the buffer has 4 bytes ack in it
+raw data length: 14
+raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
+onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
+```
+
 ![Logo](admin/wifilight.png)
 # ioBroker.wifilight 
 

--- a/devices.js
+++ b/devices.js
@@ -55,6 +55,7 @@ exports.LW12 = {
     vmax: 255,
     delay: 10,
     responseLen: 11,
+    resposneLen2: 11,
     on: [0xCC, 0x23, 0x33],
     off: [0xCC, 0x24, 0x33],
     rgb: [0x56, VARS.red, VARS.green, VARS.blue, 0xAA],
@@ -65,7 +66,7 @@ exports.LW12 = {
     programNames: programNames,
 
     decodeResponse: function(data) {
-        if (data[0] != 0x66 || data[1] != 0x01) return null;
+        if (data[0] != 0x66 || data[1] != 0x01) return [11, null];
         var result = {
             //power: ((data[2] === 0x23) ? true : false),
             on: ((data[2] === 0x23) ? true : false),
@@ -78,7 +79,7 @@ exports.LW12 = {
         };
         if (data[9] == 1 && data[10] == 0x99) {
         }
-        return result;
+        return [11, result];
     }
 };
 
@@ -89,6 +90,7 @@ exports.LD382A = {
 
     delay: 10,
     responseLen: 14,
+    responseLen2: 4,
     on: [0x71, 0x23, 0x0f],
     off: [0x71, 0x24, 0x0f],
     rgb: [0x31, VARS.red, VARS.green, VARS.blue, 0xff /*VARS.white*/, 0x00, 0x0f],
@@ -100,9 +102,11 @@ exports.LD382A = {
     programNames: programNames,
 
     decodeResponse: function(data) {
-        if (data[0] !== 129) return null;
+        // If power on / off request, result is 4 bytes long and second byte is 0x71
+        if (data[1] == 0x71) return [4, null]; // ignore it
+        if (data[0] !== 129 /* = 0x81 */) return [0, null];
         //[129, 4, 35, 97, 33, 9, 11, 22, 33, 255, 3, 0, 0, 119]
-        return {
+        return [14, {
             //power: ((data[2] === 0x23) ? true : false),
             on: ((data[2] === 0x23) ? true : false),
             //power: ((data[13] & 0x01) ? true : false),
@@ -114,7 +118,7 @@ exports.LD382A = {
             green: data[7],
             blue: data[8],
             white: data[9]
-        };
+        }];
     }
 };
 
@@ -123,8 +127,9 @@ exports.LD686 = {
      port: 5577,
      //onlyConnectOnWrite: true,
 
-      delay: 10,
+     delay: 10,
      responseLen: 14,
+     responseLen2: 14,
      on: [0x71, 0x23, 0x0f],
      off: [0x71, 0x24, 0x0f],
      //additional HEX field for RGBW. 0xF0 = RGB only; 0x0F WW only; 0xFF RGBW
@@ -137,9 +142,9 @@ exports.LD686 = {
      programNames: programNames,
 
       decodeResponse: function(data) {
-         if (data[0] !== 129) return null;
+         if (data[0] !== 129) return [0, null];
          //[129, 4, 35, 97, 33, 9, 11, 22, 33, 255, 3, 0, 0, 119]
-         return {
+         return [14, {
              //power: ((data[2] === 0x23) ? true : false),
              on: ((data[2] === 0x23) ? true : false),
              //power: ((data[13] & 0x01) ? true : false),
@@ -151,7 +156,7 @@ exports.LD686 = {
              green: data[7],
              blue: data[8],
              white: data[9]
-         };
+         }];
      }
  };
 

--- a/main.js
+++ b/main.js
@@ -716,12 +716,12 @@ WifiLight.prototype.onData = function (data) {
     this.dataBuffer.set(data, this.dataBuffer.pos);
     this.dataBuffer.pos += data.length;
 
-    while (this.dataBuffer.pos >= this.cmds.responseLen)
+    while (this.dataBuffer.pos >= this.cmds.responseLen || this.dataBuffer.pos >= this.cmds.responseLen2)
     {
-        var states = this.cmds.decodeResponse(this.dataBuffer);
-        this.log('onData: raw: ' + hex(this.dataBuffer, this.cmds.responseLen));
-        this.dataBuffer.copyWithin(0, this.cmds.responseLen, this.dataBuffer.pos);
-        this.dataBuffer.pos -= this.cmds.responseLen;
+        var [lengthRead, states] = this.cmds.decodeResponse(this.dataBuffer);
+        this.log('onData: raw: ' + hex(this.dataBuffer, lengthRead));
+        this.dataBuffer.copyWithin(0, lengthRead, this.dataBuffer.pos);
+        this.dataBuffer.pos -= lengthRead;
         if (!states) break;
         this.states = states;
         this.log('onData: ' + JSON.stringify(this.states));


### PR DESCRIPTION
I've wrote a small description of the fix in readme file. 

The problem with my wifi controller / firmware version was, that power on / power off signal gets responded by 4 bytes, which are not parsable by the adapter by default. I ignore these 4 bytes now and the adapter now works for my controller.

Maybe someone else need this fix?

Description of problem in bytes:
```
write: 81 8a 8b 96 <-- Write "Refresh command"
raw data length: 14
raw data: 81 a1 24 00 61 64 ff ff ff 02 03 01 68 76 <-- Receive data, starts every time with 0x81, when there is a refresh before (contains colors r,g,b,w, power on/off, progOn, ...)
onData: raw: 81 a1 24 00 61 64 ff ff ff 02 03 01 68 76
onData: {"on":false,"progNo":0,"progOn":false,"preogSpeed":100,"red":255,"green":255,"blue":255,"white":2} <-- Refresh works, can be parsed - okay
write: 71 23 0f a3 <-- Send Power On or off command
raw data length: 4 <-- The controller returns 4 bytes like an acknowledgement. These are ignored by the fix.
raw data: 0f 71 23 a3
raw data length: 14 <-- this is a normal refresh response
raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
onData: raw: 0f 71 23 a3 81 a1 23 00 61 64 ff ff ff 02 <-- The buffer now has 4 bytes ack + 14 bytes response = not parsable anymore
raw data length: 14
raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
raw data length: 14
raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
write: 81 8a 8b 96 <-- manual refresh also don't work, because the buffer has 4 bytes ack in it
raw data length: 14
raw data: 81 a1 23 00 61 64 ff ff ff 02 03 01 68 75
onData: raw: 03 01 68 75 81 a1 23 00 61 64 ff ff ff 02
```

Working communication sniff with MagicHome app (red, blue is the wifi controller):
![image](https://github.com/user-attachments/assets/80eb726e-84d4-451c-99e0-c644361171b0)

